### PR TITLE
Fix save compatibility with vanilla pokered-fr

### DIFF
--- a/layout.link
+++ b/layout.link
@@ -35,7 +35,7 @@ ROM0
 	"Header"
 	org $150
 	"Home"
-	org $1665
+	org $1662
 	"LoadMonFrontSprite"
 	org $1dd9
 	"JpPoint"


### PR DESCRIPTION
This PR fixes #1

The reason why you're getting stuck is because the collision data are shifted by 3 bytes, so the saved vanilla pointer points to 3 bytes earlier than its beginning.
I compared the symbols generated by pokered-gbc-fr and pokered-fr around the collision data and noticed that the first differing symbol was `LoadMonFrontSprite` at `$1665`, so I simply changed the org in `layout.link` to match the vanilla one.